### PR TITLE
Don't lie about buffer initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ An implementation of SSL streams for Tokio backed by OpenSSL
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false }
-openssl = "0.10.32"
+openssl = "0.10.61"
 openssl-sys = "0.9"
 tokio = "1.0"
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unusual_byte_groupings)]
 use std::env;
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,9 +232,7 @@ where
             match cvt(s.read_uninit(unsafe { buf.unfilled_mut() }))? {
                 Poll::Ready(nread) => {
                     // SAFETY: read_uninit guarantees that nread bytes have been initialized.
-                    unsafe {
-                        buf.assume_init(nread);
-                    }
+                    unsafe { buf.assume_init(nread) };
                     buf.advance(nread);
                     Poll::Ready(Ok(()))
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ use openssl::ssl::{self, ErrorCode, ShutdownResult, Ssl, SslRef};
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::pin::Pin;
-use std::slice;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
@@ -228,18 +227,12 @@ where
         ctx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        self.with_context(ctx, |s| {
-            // This isn't really "proper", but rust-openssl doesn't currently expose a suitable interface even though
-            // OpenSSL itself doesn't require the buffer to be initialized. So this is good enough for now.
-            let slice = unsafe {
-                let buf = buf.unfilled_mut();
-                slice::from_raw_parts_mut(buf.as_mut_ptr().cast::<u8>(), buf.len())
-            };
-            match cvt(s.read(slice))? {
+        // SAFETY: read_uninit does not de-initialize the buffer and guarantees that the first nread
+        // bytes are initialized.
+        self.with_context(ctx, |s| unsafe {
+            match cvt(s.read_uninit(buf.unfilled_mut()))? {
                 Poll::Ready(nread) => {
-                    unsafe {
-                        buf.assume_init(nread);
-                    }
+                    buf.assume_init(nread);
                     buf.advance(nread);
                     Poll::Ready(Ok(()))
                 }


### PR DESCRIPTION
It's formally UB to create a `&mut [u8]` out of possibly-uninitialized bytes. Instead, use the new `openssl` APIs that work directly with `&mut [MaybeUninit<u8>]`.

Closes #46