### PR TITLE
Update actions/checkout and actions/cache actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Rust
         run: |
           rustup update --no-self-update stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         id: rust-version
         run: echo "::set-output name=version:$(rustc --version)"
       - name: Index cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry/index
           key: index-${{ github.run_id }}
@@ -35,14 +35,14 @@ jobs:
       - name: Create lockfile
         run: cargo generate-lockfile
       - name: Registry cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry/cache
           key: registry-${{ hashFiles('Cargo.lock') }}
       - name: Fetch dependencies
         run: cargo fetch
       - name: Target cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: target
           key: target-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -11,6 +11,6 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: sfackler/actions/rustup@master
       - uses: sfackler/actions/rustfmt@master


### PR DESCRIPTION
Currently, this repository's CI is getting the following warnings:

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/cache@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

https://github.com/tokio-rs/tokio-openssl/actions/runs/7174880461

This PR fixes it.