### PR TITLE
Make future_utils a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ An implementation of SSL streams for Tokio backed by OpenSSL
 """
 
 [dependencies]
-futures-util = { version = "0.3", default-features = false }
 openssl = "0.10.61"
 openssl-sys = "0.9"
 tokio = "1.0"
 
 [dev-dependencies]
+futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1.0", features = ["full"] }

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,8 @@
 use std::env;
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(ossl111)");
+
     if let Ok(version) = env::var("DEP_OPENSSL_VERSION_NUMBER") {
         let version = u64::from_str_radix(&version, 16).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,10 @@
 //! blocking [`Read`] and [`Write`] traits.
 #![warn(missing_docs)]
 
-use futures_util::future;
 use openssl::error::ErrorStack;
 use openssl::ssl::{self, ErrorCode, ShutdownResult, Ssl, SslRef};
 use std::fmt;
+use std::future;
 use std::io::{self, Read, Write};
 use std::pin::Pin;
 use std::task::{Context, Poll};


### PR DESCRIPTION
This dep was used for future::poll_fn, which has been stabilized in rust 1.64.0:

https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html

Keeping it for tests since they also use future::join.

Thank you for the awesome tls crates!